### PR TITLE
Initialized Docker files for NestJs app

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+node_modules
+dist
+Dockerfile
+docker-compose.yml
+.git
+.gitignore
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+# Stage 1: Build
+FROM node:18-alpine as builder
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm install
+COPY . .
+
+RUN npm run build
+
+# Stage 2: Production
+FROM node:18-alpine
+
+WORKDIR /app
+
+COPY --from=builder /app/dist ./dist
+COPY package*.json ./
+
+RUN npm install
+
+EXPOSE 8080
+
+CMD ["node", "dist/main"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "8080:8080"
+    environment:
+      NODE_ENV: development
+    volumes:
+      - .:/app
+      - /app/node_modules
+    command: npm run start:dev


### PR DESCRIPTION
Initialized app with Docker default configurations for NestJs projects.
Use `docker-compose up` to run the container locally.